### PR TITLE
Added tperamun to OWNERS list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ bin
 build-harness
 build/_output
 .DS_Store
+.go/

--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ reviewers:
 - dlong-1
 - colton-nicotera
 - sophiaxu0424
+- tperamun
 approvers:
 - rbmateescu
 - kuanf


### PR DESCRIPTION
Also added .go/ folder into .gitignore file. 

The coverage reports seem to be stored under the` .go/out/codecov` folder 